### PR TITLE
fix: remove hardcoded path to claude executable

### DIFF
--- a/src/claude/agent.ts
+++ b/src/claude/agent.ts
@@ -102,7 +102,6 @@ export async function sendToAgent(
       allowedTools: ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep', 'Task'],
       permissionMode,
       abortController: controller,
-      pathToClaudeCodeExecutable: '/Users/nacho/.local/bin/claude',
       stderr: (data: string) => {
         console.error('[Claude stderr]:', data);
       },


### PR DESCRIPTION
## Summary
- Removes hardcoded `/Users/nacho/.local/bin/claude` path from `src/claude/agent.ts`
- The SDK will now use the system PATH to find the `claude` binary
- Makes the bot portable across different machines/users

## Test plan
- [ ] Verify bot starts successfully without the hardcoded path
- [ ] Confirm `claude` is found via system PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)