### PR TITLE
Add OpenCode provider support and refactor Telegraph client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -207,3 +207,15 @@ TERMINAL_UI_DEFAULT=false
 # Image Uploads
 # Max image file size in MB (Telegram limit ~20MB for downloads)
 IMAGE_MAX_FILE_SIZE_MB=20
+
+# ── OpenCode Provider ────────────────────────────────────────
+# Enable /provider command to switch between Claude and OpenCode (true/false)
+# Requires OpenCode to be installed: https://opencode.ai
+OPENCODE_ENABLED=false
+
+# URL of a running OpenCode server (e.g. http://localhost:4096)
+# If set, connects to this server. Otherwise starts an embedded server.
+# OPENCODE_BASE_URL=http://localhost:4096
+
+# Port for embedded OpenCode server (used when OPENCODE_BASE_URL is not set)
+# OPENCODE_PORT=4096

--- a/docs/index.html
+++ b/docs/index.html
@@ -1720,6 +1720,11 @@
             <h3>Model Picker</h3>
             <p>Switch between Claude models (Opus, Sonnet, Haiku) with /model. Default: Opus for best results.</p>
           </div>
+          <div class="feature-card" data-category="core">
+            <div class="feature-icon">🔌</div>
+            <h3>Provider Switching</h3>
+            <p>Switch between Claude and OpenCode with /provider. Access 75+ LLM providers when Claude is unavailable.</p>
+          </div>
           <div class="feature-card" data-category="session">
             <div class="feature-icon">🚀</div>
             <h3>Teleport to Terminal</h3>
@@ -1842,8 +1847,12 @@
           </h3>
           <div class="commands-grid">
             <div class="command-row">
+              <code class="command-code">/provider</code>
+              <span class="command-desc">Switch AI provider (Claude / OpenCode)</span>
+            </div>
+            <div class="command-row">
               <code class="command-code">/model</code>
-              <span class="command-desc">Switch Claude model (opus/sonnet/haiku)</span>
+              <span class="command-desc">Switch AI model (provider-aware)</span>
             </div>
             <div class="command-row">
               <code class="command-code">/mode</code>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.2.44",
         "@grammyjs/auto-retry": "^2.0.2",
         "@grammyjs/runner": "^2.0.3",
+        "@opencode-ai/sdk": "^1.1.53",
         "@types/turndown": "^5.0.6",
         "cheerio": "^1.2.0",
         "dotenv": "^16.4.7",
@@ -25,6 +26,9 @@
         "@types/node": "^20.17.14",
         "tsx": "^4.19.2",
         "typescript": "^5.7.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -817,6 +821,12 @@
       "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
       "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.1.53",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.1.53.tgz",
+      "integrity": "sha512-RUIVnPOP1CyyU32FrOOYuE7Ge51lOBuhaFp2NSX98ncApT7ffoNetmwzqrhOiJQgZB1KrbCHLYOCK6AZfacxag==",
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,12 @@
   ],
   "author": "",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.44",
+    "@opencode-ai/sdk": "^1.1.53",
     "@grammyjs/auto-retry": "^2.0.2",
     "@grammyjs/runner": "^2.0.3",
     "@types/turndown": "^5.0.6",

--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -27,6 +27,8 @@ import {
   handleCommands,
   handleModelCommand,
   handleModelCallback,
+  handleProviderCommand,
+  handleProviderCallback,
   handlePlan,
   handleExplore,
   handleResume,
@@ -110,6 +112,7 @@ export async function createBot(): Promise<Bot> {
     { command: 'file', description: '📎 Download a file from project' },
     { command: 'telegraph', description: '📄 View markdown with Instant View' },
     { command: 'model', description: '🤖 Switch AI model' },
+    ...(config.OPENCODE_ENABLED ? [{ command: 'provider', description: '🔌 Switch AI provider' }] : []),
     { command: 'mode', description: '⚙️ Toggle streaming mode' },
     { command: 'terminalui', description: '🖥️ Toggle terminal-style display' },
     { command: 'tts', description: '🔊 Toggle voice replies' },
@@ -150,6 +153,9 @@ export async function createBot(): Promise<Bot> {
 
   bot.command('commands', handleCommands);
   bot.command('model', handleModelCommand);
+  if (config.OPENCODE_ENABLED) {
+    bot.command('provider', handleProviderCommand);
+  }
   bot.command('plan', handlePlan);
   bot.command('explore', handleExplore);
 
@@ -195,6 +201,8 @@ export async function createBot(): Promise<Bot> {
 
     if (data.startsWith('resume:')) {
       await handleResumeCallback(ctx);
+    } else if (data.startsWith('provider:')) {
+      await handleProviderCallback(ctx);
     } else if (data.startsWith('model:')) {
       await handleModelCallback(ctx);
     } else if (data.startsWith('mode:')) {

--- a/src/bot/handlers/message.handler.ts
+++ b/src/bot/handlers/message.handler.ts
@@ -1,5 +1,5 @@
 import { Context } from 'grammy';
-import { sendToAgent, sendLoopToAgent, clearConversation, type AgentUsage } from '../../claude/agent.js';
+import { sendToAgent, sendLoopToAgent, clearConversation, type AgentUsage } from '../../providers/provider-router.js';
 import { sessionManager } from '../../claude/session-manager.js';
 import { config } from '../../config.js';
 import { messageSender } from '../../telegram/message-sender.js';

--- a/src/claude/command-parser.ts
+++ b/src/claude/command-parser.ts
@@ -6,7 +6,7 @@ export interface ParsedCommand {
   model: string | null;
 }
 
-const CLAUDE_COMMANDS = ['plan', 'explore', 'model', 'commands', 'loop', 'resume', 'continue', 'sessions'] as const;
+const CLAUDE_COMMANDS = ['plan', 'explore', 'model', 'commands', 'loop', 'resume', 'continue', 'sessions', 'provider'] as const;
 type ClaudeCommand = (typeof CLAUDE_COMMANDS)[number];
 
 export function parseClaudeCommand(message: string): ParsedCommand {
@@ -49,7 +49,8 @@ export function getAvailableCommands(): string {
         '• `/plan <task>` \\- Enter plan mode for complex tasks',
         '• `/explore <question>` \\- Use explore agent for codebase questions',
         '• `/loop <task>` \\- Run iteratively until task complete',
-        '• `/model \\[name\\]` \\- Show or set Claude model',
+        '• `/model \\[name\\]` \\- Show or set AI model',
+        ...(config.OPENCODE_ENABLED ? ['• `/provider` \\- Switch AI provider \\(Claude / OpenCode\\)'] : []),
         '• `/commands` \\- Show this list',
       ],
     },

--- a/src/claude/session-history.ts
+++ b/src/claude/session-history.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { z } from 'zod';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 
 // Zod schema for session history entry
 const sessionHistoryEntrySchema = z.object({
@@ -70,7 +71,7 @@ class SessionHistory {
 
   private save(): void {
     try {
-      fs.writeFileSync(HISTORY_FILE, JSON.stringify(this.data, null, 2), { mode: 0o600 });
+      atomicWriteFileSync(HISTORY_FILE, JSON.stringify(this.data, null, 2), { mode: 0o600 });
     } catch (error) {
       console.error('[SessionHistory] Failed to save:', error);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -199,6 +199,16 @@ const envSchema = z.object({
     .string()
     .default('0')
     .transform((val) => parseInt(val, 10)), // 0 = disabled
+  // OpenCode provider integration
+  OPENCODE_ENABLED: z
+    .string()
+    .default('false')
+    .transform((val) => val.toLowerCase() === 'true'),
+  OPENCODE_BASE_URL: z.string().optional(),
+  OPENCODE_PORT: z
+    .string()
+    .default('4096')
+    .transform((val) => parseInt(val, 10)),
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/src/providers/claude-provider.ts
+++ b/src/providers/claude-provider.ts
@@ -1,0 +1,57 @@
+import {
+  sendToAgent as claudeSendToAgent,
+  sendLoopToAgent as claudeSendLoopToAgent,
+  clearConversation as claudeClearConversation,
+  setModel as claudeSetModel,
+  getModel as claudeGetModel,
+  clearModel as claudeClearModel,
+  getCachedUsage as claudeGetCachedUsage,
+  isDangerousMode as claudeIsDangerousMode,
+} from '../claude/agent.js';
+import type { Provider, AgentOptions, LoopOptions, AgentResponse, AgentUsage, ModelInfo } from './types.js';
+
+const CLAUDE_MODELS: ModelInfo[] = [
+  { id: 'opus', label: 'opus', description: 'Most capable (default)' },
+  { id: 'sonnet', label: 'sonnet', description: 'Balanced' },
+  { id: 'haiku', label: 'haiku', description: 'Fast & light' },
+];
+
+export const claudeProvider: Provider = {
+  name: 'claude',
+
+  sendToAgent(sessionKey: string, message: string, options?: AgentOptions): Promise<AgentResponse> {
+    return claudeSendToAgent(sessionKey, message, options);
+  },
+
+  sendLoopToAgent(sessionKey: string, message: string, options?: LoopOptions): Promise<AgentResponse> {
+    return claudeSendLoopToAgent(sessionKey, message, options);
+  },
+
+  clearConversation(sessionKey: string): void {
+    claudeClearConversation(sessionKey);
+  },
+
+  setModel(chatId: number, model: string): void {
+    claudeSetModel(chatId, model);
+  },
+
+  getModel(chatId: number): string {
+    return claudeGetModel(chatId);
+  },
+
+  clearModel(chatId: number): void {
+    claudeClearModel(chatId);
+  },
+
+  getCachedUsage(sessionKey: string): AgentUsage | undefined {
+    return claudeGetCachedUsage(sessionKey);
+  },
+
+  isDangerousMode(): boolean {
+    return claudeIsDangerousMode();
+  },
+
+  async getAvailableModels(): Promise<ModelInfo[]> {
+    return CLAUDE_MODELS;
+  },
+};

--- a/src/providers/opencode-provider.ts
+++ b/src/providers/opencode-provider.ts
@@ -1,0 +1,489 @@
+import { spawn } from 'child_process';
+import { config } from '../config.js';
+import { sessionManager } from '../claude/session-manager.js';
+import { userPreferences } from './user-preferences.js';
+import { BoundedMap } from '../utils/bounded-map.js';
+import type { Provider, AgentOptions, LoopOptions, AgentResponse, AgentUsage, ModelInfo } from './types.js';
+
+// Lazy-loaded SDK types — only resolved when this provider is activated
+type OpencodeClient = Awaited<ReturnType<typeof import('@opencode-ai/sdk').createOpencodeClient>>;
+type OpencodeServer = Awaited<ReturnType<typeof import('@opencode-ai/sdk').createOpencode>>;
+
+// Per-chat state (in-memory cache)
+// chatModels is intentionally unbounded — it's backed by persistent preferences
+const chatModels = new Map<number, string>();
+const chatSessionIds = new BoundedMap<number, string>(1000);
+const chatUsageCache = new BoundedMap<number, AgentUsage>(1000);
+
+// Load persisted model preference
+function getPersistedModel(chatId: number): string | undefined {
+  return userPreferences.getModel(chatId);
+}
+
+function setPersistedModel(chatId: number, model: string): void {
+  userPreferences.setModel(chatId, model);
+}
+
+function clearPersistedModel(chatId: number): void {
+  userPreferences.clearModel(chatId);
+}
+
+// Cached model list (refreshed on /model)
+let cachedModels: ModelInfo[] | undefined;
+
+async function fetchModels(): Promise<ModelInfo[]> {
+  const c = await getClient();
+  const result = await c.config.providers();
+
+  if (result.error || !result.data) {
+    throw new Error('Failed to fetch providers');
+  }
+
+  const providersData = result.data.providers as Array<{
+    id?: string;
+    name?: string;
+    models?: Record<string, { name?: string; id?: string }>;
+  }>;
+
+  const models: ModelInfo[] = [];
+  for (const provider of providersData) {
+    const providerId = provider.id || 'unknown';
+    if (!provider.models) continue;
+    for (const [modelKey, modelConfig] of Object.entries(provider.models)) {
+      const modelId = modelConfig.id || modelKey;
+      models.push({
+        id: `${providerId}/${modelId}`,
+        label: modelConfig.name || modelId,
+        description: provider.name || providerId,
+      });
+    }
+  }
+
+  cachedModels = models;
+  return models;
+}
+
+// Singleton client + optional server handle
+let client: OpencodeClient | undefined;
+let server: OpencodeServer | undefined;
+
+async function checkExistingServer(port: number): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 2000);
+
+    const response = await fetch(`http://127.0.0.1:${port}/config/providers`, {
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+    if (!response.ok) return false;
+
+    // Verify the response looks like an OpenCode providers endpoint
+    const body = await response.json() as Record<string, unknown>;
+    return Array.isArray(body.providers);
+  } catch {
+    return false;
+  }
+}
+
+async function spawnOpencodeServer(port: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const args = ['serve', '--port', String(port)];
+
+    console.log(`[OpenCode] Spawning server: opencode ${args.join(' ')}`);
+
+    const proc = spawn('opencode', args, {
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    let stderr = '';
+    let started = false;
+
+    proc.stdout?.on('data', (data) => {
+      const line = data.toString().trim();
+      // Check if server is ready
+      if (line.includes('listening') || line.includes('ready')) {
+        if (!started) {
+          started = true;
+          resolve(`http://localhost:${port}`);
+        }
+      }
+    });
+
+    proc.stderr?.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on('error', (err) => {
+      reject(new Error(`Failed to spawn opencode: ${err.message}`));
+    });
+
+    proc.on('exit', (code) => {
+      if (code !== 0 && !started) {
+        reject(new Error(`OpenCode server exited with code ${code}. stderr: ${stderr}`));
+      }
+    });
+
+    // Timeout fallback - assume it started after 3 seconds
+    setTimeout(() => {
+      if (!started) {
+        started = true;
+        resolve(`http://localhost:${port}`);
+      }
+    }, 3000);
+  });
+}
+
+async function getClient(): Promise<OpencodeClient> {
+  if (client) return client;
+
+  try {
+    const sdk = await import('@opencode-ai/sdk');
+    const opencodeConfig = config as Record<string, unknown>;
+    let baseUrl = opencodeConfig.OPENCODE_BASE_URL as string | undefined;
+
+    if (!baseUrl && process.platform === 'win32') {
+      // On Windows, check for existing server first, then spawn if needed
+      const port = validatePort(opencodeConfig.OPENCODE_PORT);
+      const existingUrl = `http://localhost:${port}`;
+      
+      if (await checkExistingServer(port)) {
+        baseUrl = existingUrl;
+      } else {
+        baseUrl = await spawnOpencodeServer(port);
+      }
+    }
+
+    if (baseUrl) {
+      // Connect to existing running server
+      client = sdk.createOpencodeClient({ baseUrl });
+      if (!client) {
+        throw new Error('createOpencodeClient returned undefined');
+      }
+      console.log(`[OpenCode] Connected to server at ${baseUrl}`);
+    } else {
+      // Start embedded server (non-Windows)
+      const port = validatePort(opencodeConfig.OPENCODE_PORT);
+      const result = await sdk.createOpencode({ port });
+
+      // Validate result structure
+      if (!result) {
+        throw new Error('createOpencode returned undefined');
+      }
+
+      // Handle different SDK return types
+      if (typeof result === 'object' && 'client' in result) {
+        client = result.client as OpencodeClient;
+        server = result as OpencodeServer;
+      } else {
+        // SDK might return client directly
+        client = result as unknown as OpencodeClient;
+      }
+
+      if (!client) {
+        throw new Error('Failed to create OpenCode client from SDK result');
+      }
+
+      console.log(`[OpenCode] Started embedded server on port ${port}`);
+    }
+
+    // Eagerly populate the model list so getModelSpec/getModel have a default
+    if (!cachedModels) {
+      await fetchModels();
+    }
+
+    return client;
+  } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    console.error(`[OpenCode] Failed to initialize client: ${errorMsg}`);
+    throw new Error(`OpenCode initialization failed: ${errorMsg}`);
+  }
+}
+
+function validatePort(portValue: unknown): number {
+  const defaultPort = 4096;
+
+  if (portValue === undefined || portValue === null) {
+    return defaultPort;
+  }
+
+  let port: number;
+  if (typeof portValue === 'string') {
+    port = parseInt(portValue, 10);
+  } else if (typeof portValue === 'number') {
+    port = portValue;
+  } else {
+    console.warn(`[OpenCode] Invalid port type, using default ${defaultPort}`);
+    return defaultPort;
+  }
+
+  if (isNaN(port) || port < 1 || port > 65535) {
+    console.warn(`[OpenCode] Invalid port number ${port}, using default ${defaultPort}`);
+    return defaultPort;
+  }
+
+  return port;
+}
+
+async function ensureSession(chatId: number): Promise<string> {
+  const existing = chatSessionIds.get(chatId);
+  if (existing) return existing;
+
+  const c = await getClient();
+  const result = await c.session.create({
+    body: { title: `telegram-chat-${chatId}` },
+  });
+
+  if (result.error) {
+    throw new Error(`Failed to create OpenCode session: ${JSON.stringify(result.error)}`);
+  }
+
+  const sessionId = result.data.id;
+  chatSessionIds.set(chatId, sessionId);
+  return sessionId;
+}
+
+function getModelSpec(chatId: number): { providerID: string; modelID: string } {
+  // Check in-memory cache first, then persistence
+  let model = chatModels.get(chatId);
+  if (!model) {
+    model = getPersistedModel(chatId);
+    if (model) {
+      chatModels.set(chatId, model);
+    }
+  }
+  if (!model && cachedModels?.[0]) {
+    model = cachedModels[0].id;
+  }
+  if (!model) {
+    throw new Error('No model configured and no models available from OpenCode server');
+  }
+  const slashIdx = model.indexOf('/');
+  if (slashIdx > 0) {
+    return { providerID: model.slice(0, slashIdx), modelID: model.slice(slashIdx + 1) };
+  }
+  // Fallback: treat as bare model ID with anthropic provider
+  return { providerID: 'anthropic', modelID: model };
+}
+
+export const opencodeProvider: Provider = {
+  name: 'opencode',
+
+  async sendToAgent(sessionKey: string, message: string, options?: AgentOptions): Promise<AgentResponse> {
+    const chatId = Number(sessionKey.split(':')[0]);
+    const { onProgress, onToolStart, onToolEnd, abortController } = options || {};
+    const c = await getClient();
+    const sessionId = await ensureSession(chatId);
+    const modelSpec = getModelSpec(chatId);
+
+    const session = sessionManager.getSession(sessionKey);
+    if (!session) {
+      throw new Error('No active session. Use /project to set working directory.');
+    }
+    sessionManager.updateActivity(sessionKey, message);
+
+    // Send prompt
+    const promptResult = await c.session.prompt({
+      path: { id: sessionId },
+      body: {
+        model: modelSpec,
+        parts: [{ type: 'text', text: message }],
+      },
+    });
+    if (promptResult.error) {
+      throw new Error(`OpenCode prompt failed: ${JSON.stringify(promptResult.error)}`);
+    }
+
+    // Extract text from initial response (model may complete immediately)
+    let fullText = '';
+    const toolsUsed: string[] = [];
+
+    if (promptResult.data?.parts) {
+      const parts = promptResult.data.parts as Array<{ type: string; text?: string; tool?: string }>;
+      for (const part of parts) {
+        if (part.type === 'text' && part.text) {
+          fullText += part.text;
+        } else if (part.type === 'tool' && part.tool) {
+          if (!toolsUsed.includes(part.tool)) toolsUsed.push(part.tool);
+        }
+      }
+      if (fullText) {
+        onProgress?.(fullText);
+      }
+    }
+
+    // If response is complete, return immediately
+    const responseInfo = promptResult.data?.info as { finish?: string } | undefined;
+    if (responseInfo?.finish === 'stop' && fullText) {
+      return {
+        text: fullText,
+        toolsUsed,
+        usage: undefined, // Will be extracted below if needed
+      };
+    }
+
+    // Set up abort handler
+    if (abortController) {
+      const onAbort = () => {
+        c.session.abort({ path: { id: sessionId } }).catch((err: unknown) => {
+          console.error('[OpenCode] Abort failed:', err);
+        });
+      };
+      if (abortController.signal.aborted) {
+        return { text: '🛑 Request cancelled.', toolsUsed: [] };
+      }
+      abortController.signal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    // Stream events for async responses
+
+    try {
+      const events = await c.event.subscribe();
+
+      // Runtime validation: the SDK returns an object with a .stream async iterable
+      if (!events || typeof events !== 'object' || !('stream' in events)) {
+        throw new Error('Unexpected event stream shape from OpenCode SDK');
+      }
+
+      type EventStream = AsyncIterable<{ type: string; properties: Record<string, unknown> }>;
+      const stream = (events as { stream: EventStream }).stream;
+
+      for await (const event of stream) {
+        if (abortController?.signal.aborted) {
+          fullText = fullText || '🛑 Request cancelled.';
+          break;
+        }
+
+        if (event.type === 'message.part.updated') {
+          const part = event.properties.part as { type: string; sessionID: string; text?: string; tool?: string; state?: { status: string } };
+          if (part.sessionID !== sessionId) continue;
+
+          if (part.type === 'text') {
+            fullText = part.text || '';
+            onProgress?.(fullText);
+          } else if (part.type === 'tool') {
+            const toolState = part.state as { status: string } | undefined;
+            if (toolState?.status === 'running') {
+              const toolName = part.tool || 'unknown';
+              if (!toolsUsed.includes(toolName)) toolsUsed.push(toolName);
+              onToolStart?.(toolName);
+            } else if (toolState?.status === 'completed') {
+              onToolEnd?.();
+            }
+          }
+        } else if (event.type === 'session.idle') {
+          const idleSessionId = event.properties.sessionID as string;
+          if (idleSessionId === sessionId) break;
+        } else if (event.type === 'session.error') {
+          const errorSessionId = (event.properties.info as { sessionID?: string })?.sessionID
+            || event.properties.sessionID as string;
+          if (errorSessionId === sessionId) {
+            const errMsg = (event.properties as { error?: string }).error || 'Unknown OpenCode error';
+            fullText = `❌ OpenCode error: ${errMsg}`;
+            onProgress?.(fullText);
+            break;
+          }
+        }
+      }
+    } catch (err) {
+      console.error(`[OpenCode] Event stream error:`, err);
+      if (abortController?.signal.aborted) {
+        return { text: '✅ Successfully cancelled - no tools or agents in process.', toolsUsed };
+      }
+      throw err;
+    }
+
+    // Fetch final messages to extract usage
+    let resultUsage: AgentUsage | undefined;
+    try {
+      const msgsResult = await c.session.messages({ path: { id: sessionId } });
+      if (!msgsResult.error && msgsResult.data) {
+        const msgArray = msgsResult.data as Array<{
+          info: {
+            role: string;
+            tokens?: { input: number; output: number; cache?: { read: number; write: number } };
+            cost?: number;
+            modelID?: string;
+          };
+        }>;
+        const assistants = msgArray.filter(m => m.info.role === 'assistant');
+        const lastAssistant = assistants[assistants.length - 1]?.info;
+        if (lastAssistant?.tokens) {
+          resultUsage = {
+            inputTokens: lastAssistant.tokens.input || 0,
+            outputTokens: lastAssistant.tokens.output || 0,
+            cacheReadTokens: lastAssistant.tokens.cache?.read || 0,
+            cacheWriteTokens: lastAssistant.tokens.cache?.write || 0,
+            totalCostUsd: lastAssistant.cost || 0,
+            contextWindow: 200000,
+            numTurns: assistants.length,
+            model: lastAssistant.modelID || chatModels.get(chatId) || 'unknown',
+          };
+          chatUsageCache.set(chatId, resultUsage);
+        }
+      }
+    } catch {
+      // Usage extraction is best-effort
+    }
+
+    return {
+      text: fullText || 'No response from OpenCode.',
+      toolsUsed,
+      usage: resultUsage,
+    };
+  },
+
+  async sendLoopToAgent(sessionKey: string, message: string, options?: LoopOptions): Promise<AgentResponse> {
+    // OpenCode already runs full agentic loops, so delegate directly
+    return opencodeProvider.sendToAgent(sessionKey, message, options);
+  },
+
+  clearConversation(sessionKey: string): void {
+    const chatId = Number(sessionKey.split(':')[0]);
+    chatSessionIds.delete(chatId);
+    chatUsageCache.delete(chatId);
+  },
+
+  setModel(chatId: number, model: string): void {
+    chatModels.set(chatId, model);
+    setPersistedModel(chatId, model);
+  },
+
+  getModel(chatId: number): string {
+    // Check in-memory cache first, then persistence
+    let model = chatModels.get(chatId);
+    if (!model) {
+      model = getPersistedModel(chatId);
+      if (model) {
+        chatModels.set(chatId, model);
+      }
+    }
+    return model || cachedModels?.[0]?.id || 'unknown';
+  },
+
+  clearModel(chatId: number): void {
+    chatModels.delete(chatId);
+    clearPersistedModel(chatId);
+  },
+
+  getCachedUsage(sessionKey: string): AgentUsage | undefined {
+    const chatId = Number(sessionKey.split(':')[0]);
+    return chatUsageCache.get(chatId);
+  },
+
+  isDangerousMode(): boolean {
+    return false; // OpenCode manages its own permissions
+  },
+
+  async getAvailableModels(): Promise<ModelInfo[]> {
+    try {
+      return await fetchModels();
+    } catch (err) {
+      console.error('[OpenCode] Failed to fetch models:', err);
+      if (cachedModels) return cachedModels;
+      throw new Error('Failed to fetch available models from OpenCode server');
+    }
+  },
+};

--- a/src/providers/provider-router.ts
+++ b/src/providers/provider-router.ts
@@ -1,0 +1,138 @@
+import { config } from '../config.js';
+import { claudeProvider } from './claude-provider.js';
+import { userPreferences } from './user-preferences.js';
+import type { Provider, ProviderName, AgentOptions, LoopOptions, AgentResponse, AgentUsage, ModelInfo } from './types.js';
+
+// Re-export types for consumers
+export type { AgentUsage, AgentResponse, AgentOptions, LoopOptions, ModelInfo, ProviderName };
+
+// Per-chat provider selection (in-memory cache)
+const chatProviders = new Map<number, ProviderName>();
+
+// Load persisted preferences on startup
+function loadPersistedProvider(chatId: number): ProviderName | undefined {
+  return userPreferences.getProvider(chatId);
+}
+
+function savePersistedProvider(chatId: number, provider: ProviderName): void {
+  userPreferences.setProvider(chatId, provider);
+}
+
+// Lazy-loaded opencode provider (only when needed)
+let opencodeProvider: Provider | undefined;
+
+async function getOpenCodeProvider(): Promise<Provider> {
+  if (!opencodeProvider) {
+    const mod = await import('./opencode-provider.js');
+    opencodeProvider = mod.opencodeProvider;
+  }
+  return opencodeProvider;
+}
+
+// Eagerly load the OpenCode module at startup when enabled, so that
+// getProvider() never throws for users whose persisted preference is 'opencode'.
+if (config.OPENCODE_ENABLED) {
+  getOpenCodeProvider().catch((err) => {
+    console.error('[ProviderRouter] Failed to pre-load OpenCode provider:', err);
+  });
+}
+
+function getProvider(chatId: number): Provider {
+  const name = getActiveProviderName(chatId);
+  if (name === 'opencode') {
+    if (!opencodeProvider) {
+      // Fallback: if eager load hasn't completed yet, return Claude temporarily
+      console.warn('[ProviderRouter] OpenCode provider not ready yet, falling back to Claude');
+      return claudeProvider;
+    }
+    return opencodeProvider;
+  }
+  return claudeProvider;
+}
+
+// --- Public API (identical signatures to agent.ts) ---
+
+export function getActiveProviderName(chatId: number): ProviderName {
+  if (!config.OPENCODE_ENABLED) return 'claude';
+  // Check in-memory cache first
+  const cached = chatProviders.get(chatId);
+  if (cached) return cached;
+  // Load from persistence
+  const persisted = loadPersistedProvider(chatId);
+  if (persisted) {
+    chatProviders.set(chatId, persisted);
+    return persisted;
+  }
+  return 'claude';
+}
+
+export async function setActiveProvider(chatId: number, provider: ProviderName): Promise<void> {
+  if (provider === 'opencode') {
+    await getOpenCodeProvider(); // ensure loaded
+  }
+  chatProviders.set(chatId, provider);
+  savePersistedProvider(chatId, provider);
+}
+
+export function getAvailableProviders(): ProviderName[] {
+  if (!config.OPENCODE_ENABLED) return ['claude'];
+  return ['claude', 'opencode'];
+}
+
+export async function sendToAgent(
+  sessionKey: string,
+  message: string,
+  options?: AgentOptions
+): Promise<AgentResponse> {
+  const chatId = Number(sessionKey.split(':')[0]);
+  return getProvider(chatId).sendToAgent(sessionKey, message, options);
+}
+
+export async function sendLoopToAgent(
+  sessionKey: string,
+  message: string,
+  options?: LoopOptions
+): Promise<AgentResponse> {
+  const chatId = Number(sessionKey.split(':')[0]);
+  return getProvider(chatId).sendLoopToAgent(sessionKey, message, options);
+}
+
+export function clearConversation(sessionKey: string): void {
+  // Clear both providers to avoid stale state
+  claudeProvider.clearConversation(sessionKey);
+  if (opencodeProvider) {
+    opencodeProvider.clearConversation(sessionKey);
+  }
+}
+
+export function setModel(chatId: number, model: string): void {
+  getProvider(chatId).setModel(chatId, model);
+}
+
+export function getModel(chatId: number): string {
+  return getProvider(chatId).getModel(chatId);
+}
+
+export function clearModel(chatId: number): void {
+  getProvider(chatId).clearModel(chatId);
+}
+
+export function getCachedUsage(sessionKey: string): AgentUsage | undefined {
+  const chatId = Number(sessionKey.split(':')[0]);
+  return getProvider(chatId).getCachedUsage(sessionKey);
+}
+
+export function isDangerousMode(): boolean {
+  // Dangerous mode is a Claude-specific concept; always check Claude provider
+  return claudeProvider.isDangerousMode();
+}
+
+export async function getAvailableModels(chatId: number): Promise<ModelInfo[]> {
+  const providerName = getActiveProviderName(chatId);
+  if (providerName === 'opencode') {
+    // Ensure opencode provider is loaded before accessing
+    const provider = await getOpenCodeProvider();
+    return provider.getAvailableModels(chatId);
+  }
+  return claudeProvider.getAvailableModels(chatId);
+}

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,0 +1,55 @@
+export type ProviderName = 'claude' | 'opencode';
+
+export interface AgentUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalCostUsd: number;
+  contextWindow: number;
+  numTurns: number;
+  model: string;
+}
+
+export interface AgentResponse {
+  text: string;
+  toolsUsed: string[];
+  usage?: AgentUsage;
+  compaction?: { trigger: 'manual' | 'auto'; preTokens: number };
+  sessionInit?: { model: string; sessionId: string };
+}
+
+export interface AgentOptions {
+  onProgress?: (text: string) => void;
+  onToolStart?: (toolName: string, input?: Record<string, unknown>) => void;
+  onToolEnd?: () => void;
+  abortController?: AbortController;
+  command?: string;
+  model?: string;
+  /** Telegram context passed through for MCP tools (Claude provider only) */
+  telegramCtx?: unknown;
+}
+
+export interface LoopOptions extends AgentOptions {
+  maxIterations?: number;
+  onIterationComplete?: (iteration: number, response: string) => void;
+}
+
+export interface ModelInfo {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export interface Provider {
+  readonly name: ProviderName;
+  sendToAgent(sessionKey: string, message: string, options?: AgentOptions): Promise<AgentResponse>;
+  sendLoopToAgent(sessionKey: string, message: string, options?: LoopOptions): Promise<AgentResponse>;
+  clearConversation(sessionKey: string): void;
+  setModel(chatId: number, model: string): void;
+  getModel(chatId: number): string;
+  clearModel(chatId: number): void;
+  getCachedUsage(sessionKey: string): AgentUsage | undefined;
+  isDangerousMode(): boolean;
+  getAvailableModels(chatId: number): Promise<ModelInfo[]>;
+}

--- a/src/providers/user-preferences.ts
+++ b/src/providers/user-preferences.ts
@@ -1,0 +1,107 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { z } from 'zod';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
+
+// Zod schema for user preferences
+const userPreferencesSchema = z.object({
+  provider: z.enum(['claude', 'opencode']).optional(),
+  model: z.string().optional(),
+  lastUpdated: z.string(),
+});
+
+const preferencesDataSchema = z.object({
+  users: z.record(z.string(), userPreferencesSchema),
+});
+
+export type UserPreferences = z.infer<typeof userPreferencesSchema>;
+
+const PREFS_DIR = path.join(os.homedir(), '.claudegram');
+const PREFS_FILE = path.join(PREFS_DIR, 'user-preferences.json');
+
+class UserPreferencesManager {
+  private data: Record<number, UserPreferences> = {};
+
+  constructor() {
+    this.ensureDirectory();
+    this.load();
+  }
+
+  private ensureDirectory(): void {
+    if (!fs.existsSync(PREFS_DIR)) {
+      fs.mkdirSync(PREFS_DIR, { recursive: true, mode: 0o700 });
+    }
+  }
+
+  private load(): void {
+    try {
+      if (fs.existsSync(PREFS_FILE)) {
+        const content = fs.readFileSync(PREFS_FILE, 'utf-8');
+        const parsed = JSON.parse(content);
+        const validated = preferencesDataSchema.parse(parsed);
+        // Convert string keys back to numbers
+        this.data = Object.fromEntries(
+          Object.entries(validated.users).map(([k, v]) => [parseInt(k, 10), v])
+        ) as Record<number, UserPreferences>;
+      }
+    } catch (err) {
+      console.error('[UserPreferences] Failed to load preferences:', err);
+      this.data = {};
+    }
+  }
+
+  private save(): void {
+    try {
+      const toSave = {
+        users: Object.fromEntries(
+          Object.entries(this.data).map(([k, v]) => [k, v])
+        ),
+      };
+      atomicWriteFileSync(PREFS_FILE, JSON.stringify(toSave, null, 2), { mode: 0o600 });
+    } catch (err) {
+      console.error('[UserPreferences] Failed to save preferences:', err);
+    }
+  }
+
+  getProvider(chatId: number): 'claude' | 'opencode' | undefined {
+    return this.data[chatId]?.provider;
+  }
+
+  setProvider(chatId: number, provider: 'claude' | 'opencode'): void {
+    if (!this.data[chatId]) {
+      this.data[chatId] = { lastUpdated: new Date().toISOString() };
+    }
+    this.data[chatId].provider = provider;
+    this.data[chatId].lastUpdated = new Date().toISOString();
+    this.save();
+  }
+
+  getModel(chatId: number): string | undefined {
+    return this.data[chatId]?.model;
+  }
+
+  setModel(chatId: number, model: string): void {
+    if (!this.data[chatId]) {
+      this.data[chatId] = { lastUpdated: new Date().toISOString() };
+    }
+    this.data[chatId].model = model;
+    this.data[chatId].lastUpdated = new Date().toISOString();
+    this.save();
+  }
+
+  clearModel(chatId: number): void {
+    if (this.data[chatId]) {
+      delete this.data[chatId].model;
+      this.data[chatId].lastUpdated = new Date().toISOString();
+      this.save();
+    }
+  }
+
+  clearPreferences(chatId: number): void {
+    delete this.data[chatId];
+    this.save();
+  }
+}
+
+export const userPreferences = new UserPreferencesManager();

--- a/src/telegram/telegraph.ts
+++ b/src/telegram/telegraph.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { z } from 'zod';
 import { config } from '../config.js';
 import { isTelegraphEnabled } from './telegraph-settings.js';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 
 // Zod schema for Telegraph account file
 const telegraphAccountSchema = z.object({
@@ -81,7 +82,7 @@ export async function initTelegraph(): Promise<void> {
     };
 
     // Save for future use
-    fs.writeFileSync(accountFile, JSON.stringify(telegraphAccount, null, 2), { mode: 0o600 });
+    atomicWriteFileSync(accountFile, JSON.stringify(telegraphAccount, null, 2), { mode: 0o600 });
     console.log('[Telegraph] Created new account');
   } catch (error) {
     console.error('[Telegraph] Failed to initialize:', error);

--- a/src/tts/tts-settings.ts
+++ b/src/tts/tts-settings.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { z } from 'zod';
+import { atomicWriteFileSync } from '../utils/atomic-write.js';
 
 // Zod schema for TTS settings
 const ttsSettingsSchema = z.object({
@@ -96,7 +97,7 @@ function saveSettings(): void {
   }
 
   try {
-    fs.writeFileSync(SETTINGS_FILE, JSON.stringify({ settings }, null, 2), { mode: 0o600 });
+    atomicWriteFileSync(SETTINGS_FILE, JSON.stringify({ settings }, null, 2), { mode: 0o600 });
   } catch (error) {
     console.error('[TTS] Failed to save settings:', error);
   }

--- a/src/utils/atomic-write.ts
+++ b/src/utils/atomic-write.ts
@@ -1,0 +1,26 @@
+import * as fs from 'fs';
+
+/**
+ * Write a file atomically using write-to-temp + rename.
+ * On POSIX, rename is atomic. On Windows, it's best-effort but still
+ * safer than a direct writeFileSync which can corrupt on crash.
+ */
+export function atomicWriteFileSync(
+  filePath: string,
+  data: string,
+  options?: { mode?: number },
+): void {
+  const tmpPath = filePath + '.tmp';
+  try {
+    fs.writeFileSync(tmpPath, data, { mode: options?.mode });
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    // Clean up temp file on failure
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // Ignore cleanup errors
+    }
+    throw err;
+  }
+}

--- a/src/utils/bounded-map.ts
+++ b/src/utils/bounded-map.ts
@@ -1,0 +1,64 @@
+/**
+ * A Map wrapper with a configurable maximum size.
+ * When capacity is reached, the oldest entry (first inserted) is evicted.
+ * Re-setting an existing key moves it to the end (most recent).
+ */
+export class BoundedMap<K, V> {
+  private map = new Map<K, V>();
+  private readonly maxSize: number;
+
+  constructor(maxSize = 1000) {
+    this.maxSize = maxSize;
+  }
+
+  get(key: K): V | undefined {
+    return this.map.get(key);
+  }
+
+  set(key: K, value: V): this {
+    // If key already exists, delete first so re-insert moves it to the end
+    if (this.map.has(key)) {
+      this.map.delete(key);
+    } else if (this.map.size >= this.maxSize) {
+      // Evict the oldest entry (first key in insertion order)
+      const oldest = this.map.keys().next().value;
+      if (oldest !== undefined) {
+        this.map.delete(oldest);
+      }
+    }
+    this.map.set(key, value);
+    return this;
+  }
+
+  delete(key: K): boolean {
+    return this.map.delete(key);
+  }
+
+  has(key: K): boolean {
+    return this.map.has(key);
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  entries(): IterableIterator<[K, V]> {
+    return this.map.entries();
+  }
+
+  keys(): IterableIterator<K> {
+    return this.map.keys();
+  }
+
+  values(): IterableIterator<V> {
+    return this.map.values();
+  }
+
+  forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void): void {
+    this.map.forEach(callbackfn);
+  }
+}


### PR DESCRIPTION
NPM was complaining about the old Telegra.ph library so replaced it with an inline solution as well as added support for OpenCode for when I run out of Claude credits. Not sure if you want to support OpenCode if not I'll probably maintain a fork in parallel. If you do want the function, we will need to see how to update the README to handle supporting both.