### PR TITLE
fix: clamp progress bar percentage to prevent negative repeat crash

### DIFF
--- a/src/bot/handlers/message.handler.ts
+++ b/src/bot/handlers/message.handler.ts
@@ -52,9 +52,10 @@ export function fmtTokens(n: number): string {
 }
 
 export function getProgressBar(pct: number): string {
-  const filled = Math.round(pct / 10);
+  const clamped = Math.max(0, Math.min(100, pct));
+  const filled = Math.round(clamped / 10);
   const empty = 10 - filled;
-  const color = pct >= 80 ? '🔴' : pct >= 60 ? '🟡' : '🟢';
+  const color = clamped >= 80 ? '🔴' : clamped >= 60 ? '🟡' : '🟢';
   return color + ' [' + '█'.repeat(filled) + '░'.repeat(empty) + ']';
 }
 


### PR DESCRIPTION
## Summary

  Fixes a crash in `/context` when token usage exceeds the context window size.

  - `getProgressBar()` receives a percentage over 100% when cumulative tokens exceed the context
  window, causing `String.repeat()` to receive a negative value and throw `RangeError: Invalid
  count value`
  - Clamp the input percentage to 0–100 before computing bar segments

  ## Error

  RangeError: Invalid count value: -68
      at String.repeat ()
      at getProgressBar (message.handler.js:49:52)
      at handleContext (command.handler.js:837:21)

  ## Test plan

  - [x] Use a long conversation that exceeds the context window, run `/context` — should render
  without crashing
  - [x] Normal usage at <100% context still renders correctly