### PR TITLE
fix: harden SSRF, input validation, and argument injection defenses

### DIFF
--- a/src/bot/handlers/photo.handler.ts
+++ b/src/bot/handlers/photo.handler.ts
@@ -155,7 +155,8 @@ export async function handlePhoto(ctx: Context): Promise<void> {
 
   const uploadsDir = ensureUploadsDir(session.workingDirectory);
   const timestamp = Date.now();
-  const fallbackName = `photo_${timestamp}_${largest.file_unique_id}.jpg`;
+  const safeUniqueId = sanitizeFileName(largest.file_unique_id);
+  const fallbackName = `photo_${timestamp}_${safeUniqueId}.jpg`;
   const destPath = path.join(uploadsDir, fallbackName);
 
   try {


### PR DESCRIPTION
## Summary
- Validate DASH manifest-derived stream URLs with `isUrlAllowed()` before downloading (prevents SSRF via malicious `<BaseURL>` elements in manifests)
- Add `--` separator in yt-dlp invocation to prevent URL-as-flag argument injection
- Validate `claudeSessionId` format with regex before passing to `execFile`
- Whitelist Reddit `--sort` and `--time` params against valid API values
- Sanitize `file_unique_id` in photo upload path construction for consistency
- Use `sanitizeError()` on Reddit error messages to strip internal paths

## Test plan
- [x] `npm run build` — TypeScript compilation succeeds
- [x] `npm audit` — 0 vulnerabilities
- [ ] Test `/vreddit` with a Reddit video post
- [ ] Test `/reddit r/ClaudeAI --sort top --time week`
- [ ] Test photo upload via Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)