### PR TITLE
fix: clear Claude session ID when working directory changes

### DIFF
--- a/src/claude/session-manager.ts
+++ b/src/claude/session-manager.ts
@@ -75,6 +75,11 @@ class SessionManager {
   setWorkingDirectory(sessionKey: string, directory: string): Session {
     const existing = this.sessions.get(sessionKey);
     if (existing) {
+      // Clear Claude session ID when directory changes — the Agent SDK session
+      // is bound to the original cwd and cannot be resumed with a different one.
+      if (existing.workingDirectory !== directory) {
+        existing.claudeSessionId = undefined;
+      }
       existing.workingDirectory = directory;
       existing.lastActivity = new Date();
       // Save updated session


### PR DESCRIPTION
## Problem

When switching projects via `/project`, the first message always fails with `error_during_execution`. The second message works fine.

## Root Cause

`setWorkingDirectory()` preserves the Claude Agent SDK session ID from the previous project. While `clearConversation()` clears the `chatSessionIds` map in `agent.ts`, `sendToAgent()` falls back to `session.claudeSessionId`:

```typescript
const existingSessionId = chatSessionIds.get(sessionKey) || session.claudeSessionId;
//                        ^^^ cleared by clearConversation    ^^^ stale ID from old project!
```

This causes the Agent SDK to attempt resuming a session created for a different `cwd`, which returns `error_during_execution`. The error handler then clears the stale session, so the second message starts fresh and works.

## Fix

Clear `claudeSessionId` in `setWorkingDirectory()` when the directory actually changes, since the Agent SDK session is bound to the original cwd and cannot be resumed with a different one.

## Test plan

- [x] Build passes (`npm run build`)
- [x] Switch projects via `/project <name>` — first message should succeed immediately
- [x] Switch back to previous project — should also work on first message
- [x] `/resume` and `/continue` should still work (they use `resumeSession()`, not `setWorkingDirectory()`)
- [x] Setting the same directory again should NOT clear the session (no-op guard)